### PR TITLE
Loop control for API node puppetization

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -6,3 +6,4 @@ roles_path = roles/
 localhost ansible_python_interpreter="/usr/bin/env python"
 retries = 6
 timeout = 60
+retry_files_enabled = False

--- a/inventory/group_vars/api.yml
+++ b/inventory/group_vars/api.yml
@@ -1,2 +1,3 @@
 ---
 ansible_ssh_common_args: "-o ProxyCommand='ssh -W %h:%p -q {{ vm_user_account }}@{{ hostvars['puppet-node']['ansible_ssh_host'] }}'"
+loopfail: false

--- a/playbooks/puppetize_apis_loop.yml
+++ b/playbooks/puppetize_apis_loop.yml
@@ -16,3 +16,7 @@
         insertafter: import\ sys
         line: "sys.argv.append('--insecure')"
       ignore_errors: true
+# TODO: AND through api group rather than individual nodes
+# TODO: see if role could be swapped to be played last and thus failing could be done by vanilla ansible-role-puppetize/master
+    - fail:
+      when: hostvars['api-node0'].puppetize_result.rc != 0 and hostvars['api-node1'].puppetize_result.rc != 0

--- a/playbooks/puppetize_apis_loop.yml
+++ b/playbooks/puppetize_apis_loop.yml
@@ -16,7 +16,9 @@
         insertafter: import\ sys
         line: "sys.argv.append('--insecure')"
       ignore_errors: true
+# Rationale: If either puppetize completes, convergence has occurred and the other failure is probably puppetmaster acting up.
 # TODO: AND through api group rather than individual nodes
 # TODO: see if role could be swapped to be played last and thus failing could be done by vanilla ansible-role-puppetize/master
     - fail:
-      when: hostvars['api-node0'].puppetize_result.rc != 0 and hostvars['api-node1'].puppetize_result.rc != 0
+      when: hostvars['api-node0'].puppetize_result.rc != 2 and hostvars['api-node1'].puppetize_result.rc != 2
+

--- a/playbooks/puppetize_apis_loop.yml
+++ b/playbooks/puppetize_apis_loop.yml
@@ -20,5 +20,4 @@
 # TODO: AND through api group rather than individual nodes
 # TODO: see if role could be swapped to be played last and thus failing could be done by vanilla ansible-role-puppetize/master
     - fail:
-      when: hostvars['api-node0'].puppetize_result.rc != 2 and hostvars['api-node1'].puppetize_result.rc != 2
-
+      when: loopfail and hostvars['api-node0'].puppetize_result.rc != 2 and hostvars['api-node1'].puppetize_result.rc != 2


### PR DESCRIPTION
Use a host fact set in the puppetize role to determine if either API node puppetization was successful. If so, proxy successful return value to calling script/playbook, which can then further determine does API node provisioning need to continue.

Provide boolean for ignoring this loop control.