### PR TITLE
Optimizations

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,7 +28,7 @@ pipeline {
                         source ldap.sh
                     '''
                 },
-                "Bootstrap puppetmaster": {
+                "Bootstrap and puppetize puppetmaster": {
                     echo "Puppetmaster"
                     sh '''
                         source puppetmaster.sh
@@ -72,7 +72,7 @@ pipeline {
                         source puppetize-api.sh
                     '''
                 },
-                "Bootstrap Ceph nodes": {
+                "Ansiblize Ceph nodes": {
                     echo 'Ansiblizing'
                     sh '''
                         source ceph-ansible.sh

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,12 +39,6 @@ pipeline {
                     sh '''
                         source api-pre.sh
                     '''
-                },
-                "Bootstrap Ceph nodes": {
-                    echo 'Ansiblizing'
-                    sh '''
-                        source ceph-ansible.sh
-                    '''
                 })
             }
         }
@@ -70,12 +64,20 @@ pipeline {
                 })
             }
         }
-        stage('Puppetize API nodes') {
+        stage('Provision API and Ceph nodes') {
             steps {
-                echo 'Puppetizing'
-                sh '''
-                    source puppetize-api.sh
-                '''
+                parallel("Puppetize API nodes": {
+                    echo 'Puppetizing'
+                    sh '''
+                        source puppetize-api.sh
+                    '''
+                },
+                "Bootstrap Ceph nodes": {
+                    echo 'Ansiblizing'
+                    sh '''
+                        source ceph-ansible.sh
+                    '''
+                })
             }
         }
         stage('Puppetize object storage nodes') {

--- a/playbooks/puppet_environment_mods.yml
+++ b/playbooks/puppet_environment_mods.yml
@@ -8,6 +8,10 @@
   become: true
   become_user: root
   tasks:
+    - name: workaround - modify puppetdb -Xmx setting and restart services
+      shell: 'sed -i "s/512m/2048m/" "/etc/puppet/environments/{{puppet_environment}}/modules/cccp/manifests/role/puppetmaster.pp"'
+    - shell: systemctl restart puppetdb
+    - shell: systemctl restart puppetmaster
     - name: workaround - hosts file gets overwritten
       shell: 'sed -i "/hosts\.erb/d" /etc/puppet/environments/{{puppet_environment}}/modules/cccp/manifests/role.pp'
     - name: workaround - all galera nodes as master
@@ -60,7 +64,3 @@
       with_items:
         - magnum
         - barbican
-    - name: workaround - modify puppetdb -Xmx setting and restart services
-      shell: 'sed -i "s/512m/2048m/" "/etc/puppet/environments/{{puppet_environment}}/modules/cccp/manifests/role/puppetmaster.pp"'
-    - shell: systemctl restart puppetdb
-    - shell: systemctl restart puppetmaster

--- a/playbooks/puppet_environment_mods.yml
+++ b/playbooks/puppet_environment_mods.yml
@@ -60,5 +60,7 @@
       with_items:
         - magnum
         - barbican
-    - name: workaround - modify puppetdb -Xmx setting
-      shell: 'sed -i "s/512m/4096m/" "/etc/puppet/environments/{{puppet_environment}}/modules/cccp/manifests/role/puppetmaster.pp"'
+    - name: workaround - modify puppetdb -Xmx setting and restart services
+      shell: 'sed -i "s/512m/2048m/" "/etc/puppet/environments/{{puppet_environment}}/modules/cccp/manifests/role/puppetmaster.pp"'
+    - shell: systemctl restart puppetdb
+    - shell: systemctl restart puppetmaster

--- a/playbooks/puppetmaster.yml
+++ b/playbooks/puppetmaster.yml
@@ -9,5 +9,3 @@
     - { role: ansible-role-squid, internal_net: "10.99.99.0/24" }
   post_tasks:
     - shell: iptables -F
-    - shell: systemctl restart puppetdb
-    - shell: systemctl restart puppetmaster

--- a/playbooks/puppetmaster.yml
+++ b/playbooks/puppetmaster.yml
@@ -9,4 +9,5 @@
     - { role: ansible-role-squid, internal_net: "10.99.99.0/24" }
   post_tasks:
     - shell: iptables -F
-
+    - shell: systemctl restart puppetdb
+    - shell: systemctl restart puppetmaster


### PR DESCRIPTION
Give puppetdb more memory and restart puppet services before nodes are puppetized.

Provision Ceph and API nodes side-by-side to shave off a couple of minutes overall prov time.