### PR TITLE
Don't preinstall newton packages on API nodes

### DIFF
--- a/playbooks/generate_hostsfile.yml
+++ b/playbooks/generate_hostsfile.yml
@@ -18,7 +18,7 @@
 # reboots.
 
 # workaround: SELinux <> rabbitmq HiPE compilation, httpd, haproxy..
-- hosts: api:obj:compute
+- hosts: api:obj:compute:ldap
   become: yes
   become_user: root
   gather_facts: no

--- a/playbooks/pre_puppetize_apis.yml
+++ b/playbooks/pre_puppetize_apis.yml
@@ -11,19 +11,3 @@
       shell: ln -s /usr/bin/pip /usr/bin/pip-python
       args:
         creates: /usr/bin/pip-python
-# workaround: Preinstall openstack CLI
-    - shell: yum list installed python-openstackclient
-      register: pkg
-      ignore_errors: true
-    - yum:
-        name: "{{ item }}"
-        state: present
-      with_items:
-        - centos-release-openstack-newton
-        - python-openstackclient
-      when: pkg.rc != 0
-    - name: Use insecure in all /bin/openstack calls due to self-signed cert
-      lineinfile:
-        path: /bin/openstack
-        insertafter: import\ sys
-        line: "sys.argv.append('--insecure')"

--- a/playbooks/puppetize_apis_loop.yml
+++ b/playbooks/puppetize_apis_loop.yml
@@ -7,5 +7,11 @@
   pre_tasks:
     - name: Flush firewall rules for bootstrap - Puppetize will reinstate them
       shell: iptables -F
+    - name: Use insecure in all /bin/openstack calls due to self-signed cert
+      lineinfile:
+        path: /bin/openstack
+        insertafter: import\ sys
+        line: "sys.argv.append('--insecure')"
+      ignore_errors: True
   roles:
     - { role: ansible-role-puppetize, ansible_fqdn: "{{inventory_hostname_short}}.openstacklocal" }

--- a/playbooks/puppetize_compute.yml
+++ b/playbooks/puppetize_compute.yml
@@ -16,6 +16,11 @@
         path: /etc/yum.repos.d/rdo-release.repo
         regexp: 'http://mirror.centos.org.*openstack-newton/'
         replace: 'http://vault.centos.org/centos/7.4.1708/cloud/x86_64/openstack-newton/'
+    - replace:
+        path: /etc/yum.repos.d/CentOS-OpenStack-newton.repo
+        regexp: 'http://mirror.centos.org.*openstack-newton/'
+        replace: 'http://vault.centos.org/centos/7.4.1708/cloud/x86_64/openstack-newton/'
+      ignore_errors: true
     - yum:
         name: "{{ item }}"
         state: present

--- a/playbooks/puppetize_compute.yml
+++ b/playbooks/puppetize_compute.yml
@@ -8,7 +8,7 @@
         name: "{{ item }}"
         state: present
       with_items:
-        - centos-release-openstack-newton.noarch
+#        - centos-release-openstack-newton.noarch
         - unzip
         - ksh
         - libmcrypt

--- a/playbooks/puppetize_compute.yml
+++ b/playbooks/puppetize_compute.yml
@@ -4,20 +4,18 @@
   become_user: root
   pre_tasks:
 #workaround: Compensate for missing Spacewalk
-    - blockinfile:
-        path: /etc/yum.repos.d/rdo-release.repo
-        create: yes
-        block: |
-          [rdo-release]
-          name=OpenStack Newton Repository
-          baseurl=http://vault.centos.org/7.4.1708/cloud/$basearch/openstack-newton/
-          enabled=1
-          gpgcheck=1
-          gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-Cloud
     - get_url:
-        url: https://raw.githubusercontent.com/openstack/puppet-openstack_extras/master/files/RPM-GPG-KEY-CentOS-SIG-Cloud
+        url: https://raw.githubusercontent.com/rdo-infra/rdo-release/newton-rdo/rdo-release.repo
+        dest: /etc/yum.repos.d/rdo-release.repo
+        mode: 0644
+    - get_url:
+        url: https://raw.githubusercontent.com/rdo-infra/rdo-release/newton-rdo/RPM-GPG-KEY-CentOS-SIG-Cloud
         dest: /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-Cloud
         mode: 0644
+    - replace:
+        path: /etc/yum.repos.d/*
+        regexp: 'http://mirror.centos.org.*openstack-newton/'
+        replace: 'http://vault.centos.org/centos/7.4.1708/cloud/x86_64/openstack-newton/'
     - yum:
         name: "{{ item }}"
         state: present

--- a/playbooks/puppetize_compute.yml
+++ b/playbooks/puppetize_compute.yml
@@ -6,6 +6,7 @@
 #workaround: Compensate for missing Spacewalk
     - blockinfile:
         path: /etc/yum.repos.d/rdo-release.repo
+        create: yes
         block: |
           [rdo-release]
           name=OpenStack Newton Repository

--- a/playbooks/puppetize_compute.yml
+++ b/playbooks/puppetize_compute.yml
@@ -4,11 +4,24 @@
   become_user: root
   pre_tasks:
 #workaround: Compensate for missing Spacewalk
+    - blockinfile:
+        path: /etc/yum.repos.d/rdo-release.repo
+        block: |
+          [rdo-release]
+          name=OpenStack Newton Repository
+          baseurl=http://vault.centos.org/7.4.1708/cloud/$basearch/openstack-newton/
+          enabled=1
+          gpgcheck=1
+          gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-Cloud
+    - get_url:
+        url: https://raw.githubusercontent.com/openstack/puppet-openstack_extras/master/files/RPM-GPG-KEY-CentOS-SIG-Cloud
+        dest: /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-Cloud
+        mode: 0644
     - yum:
         name: "{{ item }}"
         state: present
       with_items:
-#        - centos-release-openstack-newton.noarch
+        - centos-release-openstack-newton.noarch
         - unzip
         - ksh
         - libmcrypt

--- a/playbooks/puppetize_compute.yml
+++ b/playbooks/puppetize_compute.yml
@@ -12,6 +12,7 @@
         url: https://raw.githubusercontent.com/rdo-infra/rdo-release/newton-rdo/RPM-GPG-KEY-CentOS-SIG-Cloud
         dest: /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-Cloud
         mode: 0644
+#Pin to a specific repo in CentOS vault in order to get newton packages
     - replace:
         path: /etc/yum.repos.d/rdo-release.repo
         regexp: 'http://mirror.centos.org.*openstack-newton/'

--- a/playbooks/puppetize_compute.yml
+++ b/playbooks/puppetize_compute.yml
@@ -13,7 +13,7 @@
         dest: /etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-SIG-Cloud
         mode: 0644
     - replace:
-        path: /etc/yum.repos.d/*
+        path: /etc/yum.repos.d/rdo-release.repo
         regexp: 'http://mirror.centos.org.*openstack-newton/'
         replace: 'http://vault.centos.org/centos/7.4.1708/cloud/x86_64/openstack-newton/'
     - yum:


### PR DESCRIPTION
Due to CentOS repo changes, skip preinstalling newton packages prior to puppetization. This will make end-to-end provisioning a bit slower but more consistent. 

Due to same changes, pin compute node repos to 7.4.1708 found in vault. This can be removed come O/P/Q.