### PR TITLE
Have most services use SS CA

### DIFF
--- a/playbooks/puppet_environment_mods.yml
+++ b/playbooks/puppet_environment_mods.yml
@@ -29,3 +29,23 @@
         path: "/etc/puppet/environments/{{puppet_environment}}/modules/cccp/manifests/profile/neutron.pp"
         insertafter: "::neutron::keystone::authtoken"
         line: "    cafile              => '/etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt',"
+    - name: Point cinder to SS CA
+      lineinfile:
+        path: "/etc/puppet/environments/{{puppet_environment}}/modules/cccp/manifests/profile/cinder.pp"
+        insertafter: "::cinder::keystone::authtoken"
+        line: "    cafile              => '/etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt',"
+    - name: Point heat to SS CA
+      lineinfile:
+        path: "/etc/puppet/environments/{{puppet_environment}}/modules/cccp/manifests/profile/cinder.pp"
+        insertafter: "::heat::keystone::authtoken"
+        line: "    cafile              => '/etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt',"
+    - name: Point barbican to SS CA
+      lineinfile:
+        path: "/etc/puppet/environments/{{puppet_environment}}/modules/cccp/manifests/profile/barbican.pp"
+        insertafter: "::barbican::keystone::authtoken"
+        line: "    cafile              => '/etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt',"
+    - name: Point magnum to SS CA
+      lineinfile:
+        path: "/etc/puppet/environments/{{puppet_environment}}/modules/cccp/manifests/profile/magnum.pp"
+        insertafter: "::magnum::keystone::authtoken"
+        line: "    cafile              => '/etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt',"

--- a/playbooks/puppet_environment_mods.yml
+++ b/playbooks/puppet_environment_mods.yml
@@ -47,5 +47,5 @@
     - name: Point magnum to SS CA
       lineinfile:
         path: "/etc/puppet/environments/{{puppet_environment}}/modules/cccp/manifests/profile/magnum.pp"
-        insertafter: "::magnum::keystone::authtoken"
+        insertafter: "::magnum::keystone::authtoken':"
         line: "    cafile              => '/etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt',"

--- a/playbooks/puppet_environment_mods.yml
+++ b/playbooks/puppet_environment_mods.yml
@@ -10,8 +10,8 @@
   tasks:
     - name: workaround - hosts file gets overwritten
       shell: 'sed -i "/hosts\.erb/d" /etc/puppet/environments/{{puppet_environment}}/modules/cccp/manifests/role.pp'
-    - name: workaround - use insecure for tenant creation script
-      shell: 'sed -i "s/auth=neutron_auth)/auth=neutron_auth,verify=False)/" /etc/puppet/environments/{{puppet_environment}}/modules/cccp/files/tools/create-tenants.py'
+#    - name: workaround - use insecure for tenant creation script
+#      shell: 'sed -i "s/auth=neutron_auth)/auth=neutron_auth,verify=False)/" /etc/puppet/environments/{{puppet_environment}}/modules/cccp/files/tools/create-tenants.py'
     - name: workaround - ignore public network related errors
       shell: 'sed -i "s/python create-tenants.py/python create-tenants.py||\/bin\/true/" /etc/puppet/environments/{{puppet_environment}}/modules/cccp/templates/tools/create-tenants.sh.erb'
     - name: Point nova to SS CA

--- a/playbooks/puppet_environment_mods.yml
+++ b/playbooks/puppet_environment_mods.yml
@@ -10,8 +10,6 @@
   tasks:
     - name: workaround - hosts file gets overwritten
       shell: 'sed -i "/hosts\.erb/d" /etc/puppet/environments/{{puppet_environment}}/modules/cccp/manifests/role.pp'
-#    - name: workaround - use insecure for tenant creation script
-#      shell: 'sed -i "s/auth=neutron_auth)/auth=neutron_auth,verify=False)/" /etc/puppet/environments/{{puppet_environment}}/modules/cccp/files/tools/create-tenants.py'
     - name: workaround - ignore public network related errors
       shell: 'sed -i "s/python create-tenants.py/python create-tenants.py||\/bin\/true/" /etc/puppet/environments/{{puppet_environment}}/modules/cccp/templates/tools/create-tenants.sh.erb'
     - name: Point nova to SS CA

--- a/playbooks/puppet_environment_mods.yml
+++ b/playbooks/puppet_environment_mods.yml
@@ -36,7 +36,7 @@
         line: "    cafile              => '/etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt',"
     - name: Point heat to SS CA
       lineinfile:
-        path: "/etc/puppet/environments/{{puppet_environment}}/modules/cccp/manifests/profile/cinder.pp"
+        path: "/etc/puppet/environments/{{puppet_environment}}/modules/cccp/manifests/profile/heat.pp"
         insertafter: "::heat::keystone::authtoken"
         line: "    cafile              => '/etc/pki/ca-trust/extracted/openssl/ca-bundle.trust.crt',"
     - name: Point barbican to SS CA

--- a/playbooks/puppetize_apis_loop.yml
+++ b/playbooks/puppetize_apis_loop.yml
@@ -7,12 +7,12 @@
   pre_tasks:
     - name: Flush firewall rules for bootstrap - Puppetize will reinstate them
       shell: iptables -F
-    - name: Use insecure in all /bin/openstack calls due to self-signed cert
-      lineinfile:
-        path: /bin/openstack
-        insertafter: import\ sys
-        line: "sys.argv.append('--insecure')"
-      ignore_errors: True
+#    - name: Use insecure in all /bin/openstack calls due to self-signed cert
+#      lineinfile:
+#        path: /bin/openstack
+#        insertafter: import\ sys
+#        line: "sys.argv.append('--insecure')"
+#      ignore_errors: True
     - name: Link pip-python to pip
       shell: ln -s /usr/bin/pip /usr/bin/pip-python
       args:

--- a/playbooks/puppetize_apis_loop.yml
+++ b/playbooks/puppetize_apis_loop.yml
@@ -7,12 +7,12 @@
   pre_tasks:
     - name: Flush firewall rules for bootstrap - Puppetize will reinstate them
       shell: iptables -F
-#    - name: Use insecure in all /bin/openstack calls due to self-signed cert
-#      lineinfile:
-#        path: /bin/openstack
-#        insertafter: import\ sys
-#        line: "sys.argv.append('--insecure')"
-#      ignore_errors: True
+    - name: Use insecure in all /bin/openstack calls due to self-signed cert
+      lineinfile:
+        path: /bin/openstack
+        insertafter: import\ sys
+        line: "sys.argv.append('--insecure')"
+      ignore_errors: True
     - name: Link pip-python to pip
       shell: ln -s /usr/bin/pip /usr/bin/pip-python
       args:


### PR DESCRIPTION
Configure all services (except keystone) to use a bundle that has the self-signed CA.
Remove the bit that disables SSL verification in tenant creation script.